### PR TITLE
fix: use global as default location for vertex

### DIFF
--- a/src/lmdk/providers/vertex.py
+++ b/src/lmdk/providers/vertex.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 from lmdk.datatypes import CompletionRequest
 from lmdk.provider import Provider, RawResponse
 
-DEFAULT_LOCATION = "us-central1"
+DEFAULT_LOCATION = "global"
 
 # Maps common OpenAI-style generation parameter names to Vertex AI camelCase equivalents.
 _GENERATION_KEY_MAP = {


### PR DESCRIPTION
# Description
- default location for veretex should be global, not us

## Linked Issues
Nothing

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
