### PR TITLE
Record response

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ What it offers:
 - Model fallbacks
 - Bring Your Own Key (for each provider)
 - Optional Telemetry following OpenTelemetry GenAI Semantic Conventions
+- In-process observation hook (`observe()`) to capture request/response pairs from wrapped code
 
 What it does **NOT** offer:
 - Tools / function calling / MCP
@@ -138,6 +139,25 @@ result = render_template(
     name="World"
 )
 ```
+</details>
+
+<details>
+<summary>Observing wrapped code</summary>
+
+```python
+from lmdk import observe
+
+with observe() as obs:
+    answer = my_function_that_calls_complete()
+
+for record in obs.records:
+    record.request    # CompletionRequest sent to the LM
+    record.response   # CompletionResponse returned
+```
+
+Useful for tests, evals, and debug tooling where the wrapped function only
+returns its own result but you also want to inspect the underlying LM calls.
+Streaming completions are not recorded.
 </details>
 
 ## Telemetry

--- a/src/lmdk/__init__.py
+++ b/src/lmdk/__init__.py
@@ -8,15 +8,18 @@ from lmdk.datatypes import (
     Message,
     UserMessage,
 )
+from lmdk.observe import CompletionObserver, observe
 from lmdk.utils import render_template
 
 __all__ = [
     "AssistantMessage",
+    "CompletionObserver",
     "CompletionRequest",
     "CompletionResponse",
     "Message",
     "UserMessage",
     "complete",
     "complete_batch",
+    "observe",
     "render_template",
 ]

--- a/src/lmdk/__init__.py
+++ b/src/lmdk/__init__.py
@@ -3,6 +3,7 @@
 from lmdk.core import complete, complete_batch
 from lmdk.datatypes import (
     AssistantMessage,
+    CompletionBatch,
     CompletionRequest,
     CompletionResponse,
     Message,
@@ -13,6 +14,7 @@ from lmdk.utils import render_template
 
 __all__ = [
     "AssistantMessage",
+    "CompletionBatch",
     "CompletionObserver",
     "CompletionRecord",
     "CompletionRequest",

--- a/src/lmdk/__init__.py
+++ b/src/lmdk/__init__.py
@@ -8,12 +8,13 @@ from lmdk.datatypes import (
     Message,
     UserMessage,
 )
-from lmdk.observe import CompletionObserver, observe
+from lmdk.observe import CompletionObserver, CompletionRecord, observe
 from lmdk.utils import render_template
 
 __all__ = [
     "AssistantMessage",
     "CompletionObserver",
+    "CompletionRecord",
     "CompletionRequest",
     "CompletionResponse",
     "Message",

--- a/src/lmdk/_listeners.py
+++ b/src/lmdk/_listeners.py
@@ -1,0 +1,49 @@
+"""Internal hook seam dispatched around each non-streaming completion call.
+
+This module gives :mod:`lmdk.core` a single place to plug cross-cutting
+concerns (telemetry, observation, future cost tracking, etc.) without growing
+ad-hoc branches in ``_complete_model``. Each concern lives in its own module
+and is composed here.
+
+Currently composed:
+
+- :func:`lmdk.telemetry.traced_completion` — OpenTelemetry span + metrics,
+  opt-in via the ``LMDK_TELEMETRY`` environment variable.
+- :func:`lmdk.observe._current_observer` — user-facing ``observe()`` block
+  that records :class:`CompletionResponse` objects for inspection.
+
+To add another concern, extend :func:`completion_lifecycle` rather than
+threading new arguments through ``_complete_model``.
+"""
+
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+
+from lmdk.datatypes import CompletionRequest, CompletionResponse
+from lmdk.observe import _current_observer
+from lmdk.telemetry import traced_completion
+
+
+@contextmanager
+def completion_lifecycle(
+    provider_name: str,
+    model_id: str,
+    request: CompletionRequest,
+    fallback_index: int,
+) -> Generator[Callable[[CompletionResponse], None]]:
+    """Open all hooks for a single non-streaming completion attempt.
+
+    Yields a ``record`` callable that ``_complete_model`` invokes once with
+    the final :class:`CompletionResponse`. Exceptions raised inside the block
+    propagate through ``traced_completion`` so the telemetry span captures
+    them.
+    """
+    observer = _current_observer()
+    with traced_completion(provider_name, model_id, request, fallback_index) as telemetry:
+
+        def record(response: CompletionResponse) -> None:
+            telemetry.record_response(response)
+            if observer is not None:
+                observer._record(request, response)
+
+        yield record

--- a/src/lmdk/core.py
+++ b/src/lmdk/core.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from lmdk.datatypes import CompletionRequest, CompletionResponse, Message, UserMessage
 from lmdk.errors import AllModelsFailedError
+from lmdk.observe import _current_observer
 from lmdk.provider import load_provider
 from lmdk.telemetry import traced_completion
 from lmdk.utils import parallelize_function
@@ -146,8 +147,13 @@ def _complete_model(
         response = provider.complete(request=request, stream=False)
         if isinstance(response, CompletionResponse):
             telemetry.record_response(response)
-            if return_request:
+            observer = _current_observer()
+            if return_request or observer is not None:
+                # Observers usually need the rendered prompt / gen kwargs,
+                # so force-attach the request whenever one is active.
                 response.request = request
+            if observer is not None:
+                observer._record(response)
         return response
 
 

--- a/src/lmdk/core.py
+++ b/src/lmdk/core.py
@@ -5,11 +5,10 @@ from typing import Any, Literal, overload
 
 from pydantic import BaseModel
 
+from lmdk._listeners import completion_lifecycle
 from lmdk.datatypes import CompletionRequest, CompletionResponse, Message, UserMessage
 from lmdk.errors import AllModelsFailedError
-from lmdk.observe import _current_observer
 from lmdk.provider import load_provider
-from lmdk.telemetry import traced_completion
 from lmdk.utils import parallelize_function
 
 # @overload stubs let type checkers infer the return type of ``complete`` based on ``stream``
@@ -24,7 +23,6 @@ def complete(
     *,
     stream: Literal[True],
     generation_kwargs: dict | None = None,
-    return_request: bool = False,
 ) -> Iterator[str]: ...  # stream=True  -> yields tokens one by one
 
 
@@ -36,7 +34,6 @@ def complete(
     output_schema: type[BaseModel] | None = None,
     stream: Literal[False] = False,
     generation_kwargs: dict | None = None,
-    return_request: bool = False,
 ) -> CompletionResponse: ...  # stream=False (default) -> complete response
 
 
@@ -47,7 +44,6 @@ def complete(
     output_schema: type[BaseModel] | None = None,
     stream: bool = False,
     generation_kwargs: dict | None = None,
-    return_request: bool = False,
 ) -> CompletionResponse | Iterator[str]:
     """Generate a response from a language model.
 
@@ -63,8 +59,6 @@ def complete(
         generation_kwargs: Additional generation parameters forwarded to the
             provider (e.g. ``temperature``, ``max_tokens``).
             Defaults to ``{"temperature": 0}``.
-        return_request: If ``True``, attaches the generated ``CompletionRequest`` to the
-            returned ``CompletionResponse``. Ignored if *stream* is ``True``.
 
     Returns:
         A ``CompletionResponse`` with the generated content and metadata, or an
@@ -93,7 +87,6 @@ def complete(
                 output_schema=output_schema,
                 stream=stream,
                 generation_kwargs=generation_kwargs,
-                return_request=return_request,
                 fallback_index=i,
             )
         except Exception as exc:
@@ -125,7 +118,6 @@ def _complete_model(
     output_schema: type[BaseModel] | None,
     stream: bool,
     generation_kwargs: dict,
-    return_request: bool,
     fallback_index: int,
 ) -> CompletionResponse | Iterator[str]:
     provider_name, model_id = model.split(":", maxsplit=1)
@@ -141,19 +133,12 @@ def _complete_model(
     if stream:
         return provider.complete(request=request, stream=True)
 
-    with traced_completion(
+    with completion_lifecycle(
         provider_name, model_id, request, fallback_index=fallback_index
-    ) as telemetry:
+    ) as record:
         response = provider.complete(request=request, stream=False)
         if isinstance(response, CompletionResponse):
-            telemetry.record_response(response)
-            observer = _current_observer()
-            if return_request or observer is not None:
-                # Observers usually need the rendered prompt / gen kwargs,
-                # so force-attach the request whenever one is active.
-                response.request = request
-            if observer is not None:
-                observer._record(response)
+            record(response)
         return response
 
 
@@ -164,7 +149,6 @@ def complete_batch(
     output_schema: type[BaseModel] | None = None,
     generation_kwargs: dict[str, Any] | None = None,
     max_workers: int = 10,
-    return_request: bool = False,
 ) -> list[CompletionResponse | Exception]:
     """Generate responses for multiple conversations in parallel.
 
@@ -181,8 +165,6 @@ def complete_batch(
         generation_kwargs: Additional generation parameters forwarded to the
             provider (e.g. ``temperature``, ``max_tokens``).
         max_workers: Maximum number of concurrent threads.
-        return_request: If ``True``, attaches the generated ``CompletionRequest`` to each
-            returned ``CompletionResponse``.
 
     Returns:
         A list with one entry per conversation, in the same order as
@@ -195,7 +177,6 @@ def complete_batch(
         "output_schema": output_schema,
         "stream": False,
         "generation_kwargs": generation_kwargs,
-        "return_request": return_request,
     }
     params_list = [{**shared_kwargs, "prompt": prompt} for prompt in prompt_list]
 

--- a/src/lmdk/core.py
+++ b/src/lmdk/core.py
@@ -37,6 +37,7 @@ def complete(
 ) -> CompletionResponse: ...  # stream=False (default) -> complete response
 
 
+# TODO: review the responsibilities of `complete` and `_complete_model`
 def complete(
     model: str | list[str],
     prompt: str | Sequence[Message],
@@ -186,3 +187,4 @@ def complete_batch(
         max_workers=max_workers,
         catch_exceptions=True,
     )
+    # We might want to call `CompletionBatch` here alreaady

--- a/src/lmdk/datatypes.py
+++ b/src/lmdk/datatypes.py
@@ -1,14 +1,14 @@
 """Contains the data contracts used across the app."""
 
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from itertools import chain
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
 
-@dataclass
+@dataclass(frozen=True)
 class Message:
     """Represents a single message in a conversation."""
 
@@ -20,14 +20,14 @@ class Message:
         return asdict(self)
 
 
-@dataclass
+@dataclass(frozen=True)
 class UserMessage(Message):
     """Wrapper for a message sent by the user."""
 
     role: str = "user"
 
 
-@dataclass
+@dataclass(frozen=True)
 class AssistantMessage(Message):
     """Wrapper for a message sent by the assistant."""
 
@@ -49,7 +49,7 @@ class CompletionRequest:
     generation_kwargs: dict
 
 
-@dataclass
+@dataclass(frozen=True)
 class RawResponse:
     """Lightweight intermediate result returned by provider implementations.
 
@@ -62,12 +62,12 @@ class RawResponse:
     output_tokens: int
 
 
-T = TypeVar("T", bound=BaseModel | list | None)
+T = TypeVar("T", bound=BaseModel | None)
 
 
-@dataclass
+@dataclass(frozen=True)
 class CompletionResponse(RawResponse, Generic[T]):  # noqa: UP046
-    """The result of a completion call, including usage and parsed pydantic objects.
+    """The result of a single completion call.
 
     You can hint the type of the expected object in ``.parsed`` field using annotation
     ``ParsedResponse[MyPydanticModel]``.
@@ -77,7 +77,7 @@ class CompletionResponse(RawResponse, Generic[T]):  # noqa: UP046
         input_tokens: The number of tokens consumed in the input/prompt.
         output_tokens: The number of tokens generated in the response.
         latency: The time in seconds taken to generate the response.
-        parsed: Optional parsed structured output as a BaseModel instance, list of models, or None
+        parsed: Optional parsed structured output as a BaseModel instance, or None
             if no output schema was specified.
     """
 
@@ -85,83 +85,20 @@ class CompletionResponse(RawResponse, Generic[T]):  # noqa: UP046
     parsed: T | None = None
 
     @property
-    def message(self):
+    def message(self) -> AssistantMessage:
         """Converts the response to an AssistantMessage object."""
         return AssistantMessage(self.content)
 
     @property
-    def output(self):
+    def output(self) -> Any:
         """The most useful representation of the response output.
 
-        This property intelligently extracts the most relevant part of the response:
-        - For single responses with no parsed output: returns the string content
-        - For single responses with a multi-field BaseModel: returns the entire model
-        - For single responses with a single-field BaseModel: returns just that field's value
-        - For aggregated responses (created via from_list): returns processed list of outputs
-
-        This handles common patterns where a BaseModel wraps a single value (e.g., a summary
-        string or a list of segments) for schema validation, automatically unwrapping such
-        single-field models to make the output more convenient to work with.
-
-        Returns:
-            Any: The extracted output - varies based on response structure and whether it's
-                aggregated. Could be a string, BaseModel, list, or any other type.
-        """
-        if isinstance(self.parsed, list):
-            return self._output_for_aggregated_responses()
-        return self._output_for_single_response()
-
-    @classmethod
-    def from_list(cls, responses: list["CompletionResponse"]) -> "CompletionResponse":
-        """Aggregates multiple completion responses into a single response object.
-
-        Combines multiple responses by:
-        - Collecting all parsed outputs into a list
-        - Summing input and output tokens from all responses
-        - Using the maximum latency value from all responses
-
-        Args:
-            responses: A list of CompletionResponse objects to aggregate.
-
-        Returns:
-            CompletionResponse: An aggregated response with empty content, combined token counts,
-                max latency, and all parsed outputs collected in a list.
-        """
-        aggregated_response: CompletionResponse = CompletionResponse(
-            content="", input_tokens=0, output_tokens=0, latency=0, parsed=[]
-        )
-
-        for response in responses:
-            if isinstance(response, CompletionResponse):
-                assert isinstance(aggregated_response.parsed, list)
-                if response.parsed is not None and aggregated_response.parsed is not None:
-                    aggregated_response.parsed.append(response.parsed)
-
-                # update stats
-                aggregated_response.input_tokens += response.input_tokens
-                aggregated_response.output_tokens += response.output_tokens
-                aggregated_response.latency = (
-                    response.latency
-                    if aggregated_response.latency < response.latency
-                    else aggregated_response.latency
-                )
-
-        return aggregated_response
-
-    def _output_for_single_response(self) -> Any:
-        """Extracts the output for a single response object.
-
-        Returns the most useful representation of the parsed output:
         - If there is no parsed structured output, returns the string content.
-        - If there is a parsed object with more than one field, returns the entire object.
-        - If there is a parsed object with just one field, returns the content of that field.
+        - If ``parsed`` is a BaseModel with more than one field, returns the model itself.
+        - If ``parsed`` is a BaseModel with exactly one field, returns that field's value.
 
-        This unwrapping behavior is useful for cases where a BaseModel wraps a single value
-        (e.g., a summary string or a list of segments) for schema validation purposes.
-
-        Returns:
-            Any: The extracted output - either the content string, a BaseModel, or the value
-                of a single field from a BaseModel.
+        The single-field unwrapping is useful when a schema is used purely to coerce a
+        scalar/list value (e.g. a summary string or a list of segments).
         """
         if self.parsed is None:
             return self.content
@@ -175,37 +112,56 @@ class CompletionResponse(RawResponse, Generic[T]):  # noqa: UP046
 
         return self.parsed
 
-    def _output_for_aggregated_responses(self) -> Any:
-        """Extracts the output for aggregated responses (when parsed is a list from from_list).
 
-        Processes a list of parsed outputs by:
-        1. Computing individual outputs using the unwrapping logic in _output_for_single_response
-        2. Flattening the results if all individual outputs are lists
+@dataclass(frozen=True)
+class CompletionBatch:
+    """An aggregate of multiple :class:`CompletionResponse` objects.
 
-        This is useful when aggregating multiple responses where each contains a list of items,
-        allowing you to get a single flat list rather than a list of lists.
+    Use this when you fan out a prompt over many inputs (e.g. via
+    ``complete_batch``) and want a single object that summarises token usage,
+    latency and parsed outputs across the batch.
 
-        Returns:
-            Any: An empty list if parsed is empty. Otherwise, either the individual outputs
-                (possibly flattened if all are lists) or a single flattened list if all
-                individual outputs are lists.
+    Attributes:
+        responses: The individual responses that make up the batch.
+    """
+
+    responses: list[CompletionResponse] = field(default_factory=list)
+
+    @property
+    def input_tokens(self) -> int:
+        """Total input tokens across all responses."""
+        return sum(r.input_tokens for r in self.responses)
+
+    @property
+    def output_tokens(self) -> int:
+        """Total output tokens across all responses."""
+        return sum(r.output_tokens for r in self.responses)
+
+    @property
+    def latency(self) -> float:
+        """The slowest response's latency (the batch is bounded by its tail)."""
+        return max((r.latency for r in self.responses), default=0.0)
+
+    @property
+    def parsed(self) -> list[BaseModel]:
+        """The parsed outputs of each response, skipping responses without one."""
+        return [r.parsed for r in self.responses if r.parsed is not None]
+
+    @property
+    def output(self) -> list[Any]:
+        """The per-response ``.output`` values, flattened if they are all lists.
+
+        Each response's :pyattr:`CompletionResponse.output` is computed individually
+        (so single-field BaseModels are unwrapped). If every resulting value is a
+        list, the lists are concatenated into one flat list; otherwise the list of
+        per-response outputs is returned as-is.
         """
-        if not self.parsed:
+        if not self.responses:
             return []
 
-        # Compute what each individual response.output would be
-        individual_outputs = []
-        for obj in self.parsed:
-            if isinstance(obj, BaseModel) and len(fields := type(obj).model_fields) == 1:
-                # Single field: unwrap it
-                field_name = next(iter(fields.keys()))
-                individual_outputs.append(getattr(obj, field_name))
+        individual = [r.output for r in self.responses]
 
-            else:
-                individual_outputs.append(obj)
+        if individual and all(isinstance(out, list) for out in individual):
+            return list(chain.from_iterable(individual))
 
-        # Flatten if all individual outputs are lists
-        if individual_outputs and all(isinstance(out, list) for out in individual_outputs):
-            return list(chain.from_iterable(individual_outputs))
-
-        return individual_outputs
+        return individual

--- a/src/lmdk/datatypes.py
+++ b/src/lmdk/datatypes.py
@@ -1,7 +1,7 @@
 """Contains the data contracts used across the app."""
 
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from itertools import chain
 from typing import Any, Generic, TypeVar
 
@@ -79,13 +79,10 @@ class CompletionResponse(RawResponse, Generic[T]):  # noqa: UP046
         latency: The time in seconds taken to generate the response.
         parsed: Optional parsed structured output as a BaseModel instance, list of models, or None
             if no output schema was specified.
-        request: The ``CompletionRequest`` used to generate this response. Only populated if
-            the response was requested with ``return_request=True``.
     """
 
     latency: float = 0.0
     parsed: T | None = None
-    request: CompletionRequest | None = field(default=None, repr=False)
 
     @property
     def message(self):

--- a/src/lmdk/observe.py
+++ b/src/lmdk/observe.py
@@ -1,0 +1,72 @@
+"""Observation hook for capturing completions made inside a code block.
+
+This is useful when a caller wraps user code that ends up calling
+:func:`lmdk.complete` and wants to inspect the resulting
+:class:`CompletionResponse` (and its originating :class:`CompletionRequest`)
+without forcing the user code to return it.
+
+The mechanism is a :mod:`contextvars`-scoped recorder. While a call site is
+inside an :func:`observe` block, every non-streaming completion produced by
+``lmdk.complete`` is appended to the active observer. Streaming calls are
+ignored — there is no single response to record.
+
+Example:
+    >>> with observe() as obs:
+    ...     answer = my_function_that_calls_complete()
+    >>> obs.responses[0].latency
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+from lmdk.datatypes import CompletionResponse
+
+
+class CompletionObserver:
+    """Collects :class:`CompletionResponse` objects produced while active.
+
+    Responses are appended in the order ``lmdk.complete`` returns them. The
+    originating :class:`CompletionRequest` is always attached to
+    ``response.request`` when an observer is active, regardless of the
+    ``return_request`` flag — observers usually need it (for the rendered
+    prompt, generation kwargs, etc.).
+    """
+
+    def __init__(self) -> None:
+        self.responses: list[CompletionResponse] = []
+
+    def _record(self, response: CompletionResponse) -> None:
+        self.responses.append(response)
+
+
+_active_observer: ContextVar[CompletionObserver | None] = ContextVar(
+    "lmdk_active_observer", default=None
+)
+
+
+@contextmanager
+def observe() -> Iterator[CompletionObserver]:
+    """Capture every completion produced by ``lmdk.complete`` inside the block.
+
+    Yields a fresh :class:`CompletionObserver` whose ``responses`` list is
+    populated as completions finish. Observers nest: an inner ``observe``
+    block shadows the outer one for the duration of its scope, so inner
+    completions land on the inner observer only.
+
+    The recorder is stored in a :class:`~contextvars.ContextVar`, so each
+    thread / async task sees its own active observer. Completions made on
+    threads spawned inside the block do **not** automatically inherit the
+    observer unless the caller propagates the context explicitly.
+    """
+    observer = CompletionObserver()
+    token = _active_observer.set(observer)
+    try:
+        yield observer
+    finally:
+        _active_observer.reset(token)
+
+
+def _current_observer() -> CompletionObserver | None:
+    """Return the active observer, or ``None`` if no ``observe`` block is open."""
+    return _active_observer.get()

--- a/src/lmdk/observe.py
+++ b/src/lmdk/observe.py
@@ -2,42 +2,49 @@
 
 This is useful when a caller wraps user code that ends up calling
 :func:`lmdk.complete` and wants to inspect the resulting
-:class:`CompletionResponse` (and its originating :class:`CompletionRequest`)
-without forcing the user code to return it.
+:class:`CompletionRequest` / :class:`CompletionResponse` pairs without
+forcing the user code to return them.
 
 The mechanism is a :mod:`contextvars`-scoped recorder. While a call site is
 inside an :func:`observe` block, every non-streaming completion produced by
-``lmdk.complete`` is appended to the active observer. Streaming calls are
-ignored — there is no single response to record.
+``lmdk.complete`` is appended to the active observer as a
+:class:`CompletionRecord`. Streaming calls are ignored — there is no single
+response to record.
 
 Example:
     >>> with observe() as obs:
     ...     answer = my_function_that_calls_complete()
-    >>> obs.responses[0].latency
+    >>> obs.records[0].response.latency
+    >>> obs.records[0].request.prompt
 """
 
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 
-from lmdk.datatypes import CompletionResponse
+from lmdk.datatypes import CompletionRequest, CompletionResponse
+
+
+@dataclass(frozen=True)
+class CompletionRecord:
+    """A single (request, response) pair captured by an :func:`observe` block."""
+
+    request: CompletionRequest
+    response: CompletionResponse
 
 
 class CompletionObserver:
-    """Collects :class:`CompletionResponse` objects produced while active.
+    """Collects :class:`CompletionRecord` entries produced while active.
 
-    Responses are appended in the order ``lmdk.complete`` returns them. The
-    originating :class:`CompletionRequest` is always attached to
-    ``response.request`` when an observer is active, regardless of the
-    ``return_request`` flag — observers usually need it (for the rendered
-    prompt, generation kwargs, etc.).
+    Records are appended in the order ``lmdk.complete`` returns them.
     """
 
     def __init__(self) -> None:
-        self.responses: list[CompletionResponse] = []
+        self.records: list[CompletionRecord] = []
 
-    def _record(self, response: CompletionResponse) -> None:
-        self.responses.append(response)
+    def _record(self, request: CompletionRequest, response: CompletionResponse) -> None:
+        self.records.append(CompletionRecord(request=request, response=response))
 
 
 _active_observer: ContextVar[CompletionObserver | None] = ContextVar(

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from lmdk.datatypes import (
     AssistantMessage,
+    CompletionBatch,
     CompletionRequest,
     CompletionResponse,
     Message,
@@ -173,91 +174,87 @@ class TestOutputSingleResponse:
 
 
 # ---------------------------------------------------------------------------
-# CompletionResponse.from_list — aggregation
+# CompletionBatch — aggregation
 # ---------------------------------------------------------------------------
 
 
-class TestFromList:
+class TestCompletionBatch:
     def test_aggregates_tokens(self):
-        responses = [
-            _resp(input_tokens=10, output_tokens=5, latency=0.1),
-            _resp(input_tokens=20, output_tokens=15, latency=0.2),
-        ]
-        agg = CompletionResponse.from_list(responses)
-        assert agg.input_tokens == 30
-        assert agg.output_tokens == 20
+        batch = CompletionBatch(
+            responses=[
+                _resp(input_tokens=10, output_tokens=5, latency=0.1),
+                _resp(input_tokens=20, output_tokens=15, latency=0.2),
+            ]
+        )
+        assert batch.input_tokens == 30
+        assert batch.output_tokens == 20
 
     def test_latency_is_max(self):
-        responses = [
-            _resp(latency=0.1),
-            _resp(latency=0.5),
-            _resp(latency=0.3),
-        ]
-        agg = CompletionResponse.from_list(responses)
-        assert agg.latency == 0.5
+        batch = CompletionBatch(
+            responses=[_resp(latency=0.1), _resp(latency=0.5), _resp(latency=0.3)]
+        )
+        assert batch.latency == 0.5
 
     def test_collects_parsed_objects(self):
         r1 = _resp(parsed=SingleField(summary="a"))
         r2 = _resp(parsed=SingleField(summary="b"))
-        agg = CompletionResponse.from_list([r1, r2])
+        batch = CompletionBatch(responses=[r1, r2])
 
-        assert isinstance(agg.parsed, list)
-        assert len(agg.parsed) == 2
-        assert agg.parsed[0].summary == "a"
-        assert agg.parsed[1].summary == "b"
+        assert len(batch.parsed) == 2
+        assert batch.parsed[0].summary == "a"
+        assert batch.parsed[1].summary == "b"
 
     def test_skips_none_parsed(self):
         r1 = _resp(parsed=SingleField(summary="a"))
         r2 = _resp(parsed=None)
-        agg = CompletionResponse.from_list([r1, r2])
+        batch = CompletionBatch(responses=[r1, r2])
+        assert len(batch.parsed) == 1
 
-        assert isinstance(agg.parsed, list)
-        assert len(agg.parsed) == 1
+    def test_empty_batch(self):
+        batch = CompletionBatch(responses=[])
+        assert batch.input_tokens == 0
+        assert batch.output_tokens == 0
+        assert batch.latency == 0.0
+        assert batch.parsed == []
 
-    def test_empty_list(self):
-        agg = CompletionResponse.from_list([])
-        assert agg.input_tokens == 0
-        assert agg.output_tokens == 0
-        assert agg.parsed == []
-
-    def test_content_is_empty(self):
-        agg = CompletionResponse.from_list([_resp(content="hello")])
-        assert agg.content == ""
+    def test_frozen(self):
+        batch = CompletionBatch(responses=[])
+        with pytest.raises(FrozenInstanceError):
+            batch.responses = [_resp()]
 
 
 # ---------------------------------------------------------------------------
-# CompletionResponse.output — aggregated responses
+# CompletionBatch.output
 # ---------------------------------------------------------------------------
 
 
-class TestOutputAggregated:
+class TestCompletionBatchOutput:
     def test_single_field_models_unwrap(self):
-        responses = [
-            _resp(parsed=SingleField(summary="a")),
-            _resp(parsed=SingleField(summary="b")),
-        ]
-        agg = CompletionResponse.from_list(responses)
-        assert agg.output == ["a", "b"]
+        batch = CompletionBatch(
+            responses=[
+                _resp(parsed=SingleField(summary="a")),
+                _resp(parsed=SingleField(summary="b")),
+            ]
+        )
+        assert batch.output == ["a", "b"]
 
     def test_multi_field_models_stay_as_models(self):
         m1 = MultiField(title="A", score=0.9)
         m2 = MultiField(title="B", score=0.8)
-        responses = [_resp(parsed=m1), _resp(parsed=m2)]
-        agg = CompletionResponse.from_list(responses)
-
-        assert agg.output == [m1, m2]
+        batch = CompletionBatch(responses=[_resp(parsed=m1), _resp(parsed=m2)])
+        assert batch.output == [m1, m2]
 
     def test_list_fields_flatten(self):
-        responses = [
-            _resp(parsed=ListField(items=["a", "b"])),
-            _resp(parsed=ListField(items=["c"])),
-        ]
-        agg = CompletionResponse.from_list(responses)
-        assert agg.output == ["a", "b", "c"]
+        batch = CompletionBatch(
+            responses=[
+                _resp(parsed=ListField(items=["a", "b"])),
+                _resp(parsed=ListField(items=["c"])),
+            ]
+        )
+        assert batch.output == ["a", "b", "c"]
 
-    def test_empty_aggregation_returns_empty_list(self):
-        agg = CompletionResponse.from_list([])
-        assert agg.output == []
+    def test_empty_batch_returns_empty_list(self):
+        assert CompletionBatch(responses=[]).output == []
 
     def test_mixed_list_and_scalar_does_not_flatten(self):
         """When not all outputs are lists, no flattening occurs."""
@@ -265,10 +262,11 @@ class TestOutputAggregated:
         class MixedField(BaseModel):
             value: str
 
-        responses = [
-            _resp(parsed=ListField(items=["a", "b"])),
-            _resp(parsed=MixedField(value="c")),
-        ]
-        agg = CompletionResponse.from_list(responses)
+        batch = CompletionBatch(
+            responses=[
+                _resp(parsed=ListField(items=["a", "b"])),
+                _resp(parsed=MixedField(value="c")),
+            ]
+        )
         # First unwraps to ["a", "b"], second unwraps to "c" — not all lists
-        assert agg.output == [["a", "b"], "c"]
+        assert batch.output == [["a", "b"], "c"]

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -1,0 +1,137 @@
+"""Tests for ``lmdk.observe`` and the listener seam in ``lmdk._listeners``.
+
+These tests use the ``patch_load_provider`` fixture from ``conftest.py`` so
+no real provider is hit.
+"""
+
+import pytest
+
+from lmdk import observe
+from lmdk.core import complete, complete_batch
+from lmdk.datatypes import CompletionRequest, CompletionResponse
+from lmdk.errors import ProviderError
+from lmdk.observe import CompletionObserver, CompletionRecord, _current_observer
+from lmdk.provider import RawResponse
+
+
+class TestObserverBasics:
+    def test_observer_starts_empty(self):
+        with observe() as obs:
+            assert obs.records == []
+
+    def test_no_active_observer_outside_block(self):
+        assert _current_observer() is None
+        with observe():
+            pass
+        assert _current_observer() is None
+
+    def test_records_single_completion(self, patch_load_provider):
+        with observe() as obs:
+            response = complete(model="fake:model", prompt="hi")
+
+        assert len(obs.records) == 1
+        record = obs.records[0]
+        assert isinstance(record, CompletionRecord)
+        assert isinstance(record.request, CompletionRequest)
+        assert isinstance(record.response, CompletionResponse)
+        # The recorded response is the same object returned to the caller.
+        assert record.response is response
+        # The recorded request matches what was sent to the provider.
+        assert record.request.model_id == "model"
+        assert record.request.prompt[0].content == "hi"
+
+    def test_records_multiple_completions_in_order(self, patch_load_provider):
+        with observe() as obs:
+            complete(model="fake:model", prompt="first")
+            complete(model="fake:model", prompt="second")
+            complete(model="fake:model", prompt="third")
+
+        assert [r.request.prompt[0].content for r in obs.records] == [
+            "first",
+            "second",
+            "third",
+        ]
+
+
+class TestObserverScope:
+    def test_no_recording_outside_block(self, patch_load_provider):
+        observer = CompletionObserver()
+        complete(model="fake:model", prompt="hi")
+        assert observer.records == []
+
+    def test_observer_inactive_after_block_exits(self, patch_load_provider):
+        with observe() as obs:
+            complete(model="fake:model", prompt="inside")
+        # Subsequent calls do not land in obs.
+        complete(model="fake:model", prompt="outside")
+        assert len(obs.records) == 1
+        assert obs.records[0].request.prompt[0].content == "inside"
+
+    def test_nested_observers_isolate(self, patch_load_provider):
+        with observe() as outer:
+            complete(model="fake:model", prompt="outer-before")
+            with observe() as inner:
+                complete(model="fake:model", prompt="inner-1")
+                complete(model="fake:model", prompt="inner-2")
+            complete(model="fake:model", prompt="outer-after")
+
+        assert [r.request.prompt[0].content for r in inner.records] == [
+            "inner-1",
+            "inner-2",
+        ]
+        assert [r.request.prompt[0].content for r in outer.records] == [
+            "outer-before",
+            "outer-after",
+        ]
+
+    def test_streaming_calls_are_not_recorded(self, patch_load_provider):
+        with observe() as obs:
+            list(complete(model="fake:model", prompt="hi", stream=True))
+        assert obs.records == []
+
+    def test_failed_call_is_not_recorded(self, patch_load_provider):
+        def boom(request, credentials):
+            raise ProviderError(status_code=500, message="server error", provider="fake")
+
+        patch_load_provider.response_fn = boom
+
+        with observe() as obs, pytest.raises(ProviderError):
+            complete(model="fake:model", prompt="hi")
+
+        assert obs.records == []
+
+    def test_only_successful_fallback_is_recorded(self, patch_load_provider):
+        call_count = {"n": 0}
+
+        def fail_then_succeed(request, credentials):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise ProviderError(status_code=500, message="down", provider="fake")
+            return RawResponse(content="from fallback", input_tokens=1, output_tokens=2)
+
+        patch_load_provider.response_fn = fail_then_succeed
+
+        with observe() as obs:
+            response = complete(model=["fake:bad", "fake:good"], prompt="hi")
+
+        assert len(obs.records) == 1
+        assert obs.records[0].response is response
+        assert obs.records[0].request.model_id == "good"
+
+
+class TestObserverWithBatch:
+    def test_batch_calls_do_not_propagate_to_observer(self, patch_load_provider):
+        """Documented behavior: contextvars don't follow threads spawned by
+        ``complete_batch``, so calls inside the pool are not recorded.
+        If this ever changes (e.g. via ``contextvars.copy_context``), this
+        test should be flipped to assert propagation.
+        """
+        with observe() as obs:
+            results = complete_batch(
+                model="fake:model",
+                prompt_list=["a", "b", "c"],
+                max_workers=2,
+            )
+
+        assert len(results) == 3
+        assert obs.records == []

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "lmdk"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
# Description
- I added an `observer` that consumers can use to get both request and response in functions that call LMs. This is thought mainly for the bench
- Since now we have context managers for both `observe`  and `telemetry` , I abstracted a `_listener` module to handle both and keep `core.py` lean
- `CompletionResponse` attribute `.request` is not necessary anymore. Users that want that can simply observe their function
- I froze all dataclasses that should not be mutable. For this, I had to make a separate `CompletionBatch` class for the case that we were doing `CompletionResponse.from_list`. That is a **breaking change**

## Linked Issues
None

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
