### PR TITLE
Improve batch completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,18 @@ response = complete(model=model, prompt="How do I make cheescake?", output_schem
 ```python
 from lmdk import complete_batch
 
-results = complete_batch(model=model, prompt_list=["Greet in english", "Saluda en espanyol."])
-# results will be al list of CompletionResult
+batch = complete_batch(model=model, prompt_list=["Greet in english", "Saluda en espanyol."])
+# `batch` is a CompletionBatch. Iterate it to handle each outcome:
+for result in batch:
+    if isinstance(result, Exception):
+        ...  # this prompt failed
+    else:
+        ...  # CompletionResponse
+
+# Aggregates over successful responses:
+batch.input_tokens, batch.output_tokens, batch.latency
+batch.responses  # successes only
+batch.errors     # exceptions only
 ```
 </details>
 

--- a/example.py
+++ b/example.py
@@ -218,14 +218,15 @@ def main(model: str) -> None:
 
     # ── Section 10: Batch responses ───────────────────────────────────────
     # complete_batch sends multiple prompts in parallel using a thread
-    # pool.  Each result is either a CompletionResponse or an Exception.
+    # pool and returns a CompletionBatch. Iterating yields each outcome,
+    # which is either a CompletionResponse or an Exception.
     section(10, "Batch responses")
     try:
-        results = complete_batch(
+        batch = complete_batch(
             model=model,
             prompt_list=["Say 'hello' and nothing else.", "Say 'hola' and nothing else."],
         )
-        for i, result in enumerate(results):
+        for i, result in enumerate(batch):
             if isinstance(result, Exception):
                 print(f"  [{i}] [FAILED] {type(result).__name__}: {result}")
             else:
@@ -234,6 +235,10 @@ def main(model: str) -> None:
                     f"tokens={result.input_tokens}+{result.output_tokens}  "
                     f"latency={result.latency:.3f}s"
                 )
+        print(
+            f"  batch totals: input={batch.input_tokens}  output={batch.output_tokens}  "
+            f"latency={batch.latency:.3f}s  errors={len(batch.errors)}"
+        )
     except Exception as e:
         print(f"[FAILED] Batch responses -> {type(e).__name__}: {e}")
 
@@ -242,7 +247,7 @@ def main(model: str) -> None:
     # will have .parsed and .output populated.
     section(11, "Batch with structured output")
     try:
-        results = complete_batch(
+        batch = complete_batch(
             model=model,
             prompt_list=[
                 "Tell me about Tokyo.",
@@ -250,7 +255,7 @@ def main(model: str) -> None:
             ],
             output_schema=City,
         )
-        for i, result in enumerate(results):
+        for i, result in enumerate(batch):
             if isinstance(result, Exception):
                 print(f"  [{i}] [FAILED] {type(result).__name__}: {result}")
             else:

--- a/src/lmdk/core.py
+++ b/src/lmdk/core.py
@@ -6,7 +6,13 @@ from typing import Any, Literal, overload
 from pydantic import BaseModel
 
 from lmdk._listeners import completion_lifecycle
-from lmdk.datatypes import CompletionRequest, CompletionResponse, Message, UserMessage
+from lmdk.datatypes import (
+    CompletionBatch,
+    CompletionRequest,
+    CompletionResponse,
+    Message,
+    UserMessage,
+)
 from lmdk.errors import AllModelsFailedError
 from lmdk.provider import load_provider
 from lmdk.utils import parallelize_function
@@ -150,7 +156,7 @@ def complete_batch(
     output_schema: type[BaseModel] | None = None,
     generation_kwargs: dict[str, Any] | None = None,
     max_workers: int = 10,
-) -> list[CompletionResponse | Exception]:
+) -> CompletionBatch:
     """Generate responses for multiple conversations in parallel.
 
     Each conversation in *prompt_list* is dispatched to :func:`complete`
@@ -168,9 +174,13 @@ def complete_batch(
         max_workers: Maximum number of concurrent threads.
 
     Returns:
-        A list with one entry per conversation, in the same order as
-        *prompt_list*.  Each entry is either a ``CompletionResponse`` on
-        success or the ``Exception`` that was raised on failure.
+        A :class:`CompletionBatch` whose ``results`` list has one entry per
+        conversation, in the same order as *prompt_list*. Each entry is either
+        a ``CompletionResponse`` on success or the ``Exception`` raised on
+        failure. The batch is iterable and indexable for direct access to
+        these outcomes, and exposes aggregate properties (``input_tokens``,
+        ``output_tokens``, ``latency``, ``parsed``, ``output``) computed over
+        the successful responses.
     """
     shared_kwargs: dict[str, Any] = {
         "model": model,
@@ -181,10 +191,10 @@ def complete_batch(
     }
     params_list = [{**shared_kwargs, "prompt": prompt} for prompt in prompt_list]
 
-    return parallelize_function(
+    results = parallelize_function(
         function=complete,
         params_list=params_list,
         max_workers=max_workers,
         catch_exceptions=True,
     )
-    # We might want to call `CompletionBatch` here alreaady
+    return CompletionBatch(results=results)

--- a/src/lmdk/datatypes.py
+++ b/src/lmdk/datatypes.py
@@ -1,6 +1,6 @@
 """Contains the data contracts used across the app."""
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import asdict, dataclass, field
 from itertools import chain
 from typing import Any, Generic, TypeVar
@@ -115,36 +115,72 @@ class CompletionResponse(RawResponse, Generic[T]):  # noqa: UP046
 
 @dataclass(frozen=True)
 class CompletionBatch:
-    """An aggregate of multiple :class:`CompletionResponse` objects.
+    """An aggregate of multiple completion outcomes.
 
     Use this when you fan out a prompt over many inputs (e.g. via
     ``complete_batch``) and want a single object that summarises token usage,
     latency and parsed outputs across the batch.
 
+    Each entry in ``results`` is either a :class:`CompletionResponse` on
+    success or the :class:`Exception` that was raised for that input. The
+    order matches the order of inputs passed to ``complete_batch``.
+
+    Iterating or indexing the batch iterates ``results`` directly, so callers
+    can branch on each outcome::
+
+        for outcome in batch:
+            if isinstance(outcome, Exception):
+                ...
+            else:
+                ...
+
+    Aggregations (``input_tokens``, ``output_tokens``, ``latency``,
+    ``parsed``, ``output``) are computed over **successful** responses only.
+
     Attributes:
-        responses: The individual responses that make up the batch.
+        results: The per-input outcomes, each a ``CompletionResponse`` or
+            ``Exception``.
     """
 
-    responses: list[CompletionResponse] = field(default_factory=list)
+    results: list[CompletionResponse | Exception] = field(default_factory=list)
+
+    def __iter__(self) -> Iterator[CompletionResponse | Exception]:
+        return iter(self.results)
+
+    def __len__(self) -> int:
+        return len(self.results)
+
+    def __getitem__(self, index: int) -> CompletionResponse | Exception:
+        return self.results[index]
+
+    @property
+    def responses(self) -> list[CompletionResponse]:
+        """The successful responses, in original input order."""
+        return [r for r in self.results if isinstance(r, CompletionResponse)]
+
+    @property
+    def errors(self) -> list[Exception]:
+        """The exceptions raised for failed inputs, in original input order."""
+        return [r for r in self.results if isinstance(r, Exception)]
 
     @property
     def input_tokens(self) -> int:
-        """Total input tokens across all responses."""
+        """Total input tokens across successful responses."""
         return sum(r.input_tokens for r in self.responses)
 
     @property
     def output_tokens(self) -> int:
-        """Total output tokens across all responses."""
+        """Total output tokens across successful responses."""
         return sum(r.output_tokens for r in self.responses)
 
     @property
     def latency(self) -> float:
-        """The slowest response's latency (the batch is bounded by its tail)."""
+        """The slowest successful response's latency (the batch is bounded by its tail)."""
         return max((r.latency for r in self.responses), default=0.0)
 
     @property
     def parsed(self) -> list[BaseModel]:
-        """The parsed outputs of each response, skipping responses without one."""
+        """The parsed outputs of successful responses, skipping ones without one."""
         return [r.parsed for r in self.responses if r.parsed is not None]
 
     @property
@@ -154,12 +190,13 @@ class CompletionBatch:
         Each response's :pyattr:`CompletionResponse.output` is computed individually
         (so single-field BaseModels are unwrapped). If every resulting value is a
         list, the lists are concatenated into one flat list; otherwise the list of
-        per-response outputs is returned as-is.
+        per-response outputs is returned as-is. Failed entries are skipped.
         """
-        if not self.responses:
+        responses = self.responses
+        if not responses:
             return []
 
-        individual = [r.output for r in self.responses]
+        individual = [r.output for r in responses]
 
         if individual and all(isinstance(out, list) for out in individual):
             return list(chain.from_iterable(individual))

--- a/src/lmdk/utils.py
+++ b/src/lmdk/utils.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextvars import copy_context
 from functools import wraps
 from pathlib import Path
 from typing import Any
@@ -45,6 +46,13 @@ def parallelize_function(
     Returns:
         A list of results in the same order as *params_list*.
 
+    Notes:
+        Each task runs inside a snapshot of the submitting thread's
+        :mod:`contextvars` context (via :func:`contextvars.copy_context`), so
+        context-scoped state like the active ``lmdk.observe`` recorder and
+        OpenTelemetry baggage is visible to the worker threads. Mutations to
+        ``ContextVar`` values inside a task stay local to that task.
+
     Examples:
         >>> def add(a, b):
         ...     return a + b
@@ -64,7 +72,8 @@ def parallelize_function(
     results: list[Any] = [None] * len(params_list)
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures_to_indices = {
-            executor.submit(function, **params): index for index, params in enumerate(params_list)
+            executor.submit(copy_context().run, function, **params): index
+            for index, params in enumerate(params_list)
         }
         for future in as_completed(futures_to_indices):
             index = futures_to_indices[future]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -159,15 +159,16 @@ class TestCompleteBatch:
 
         patch_load_provider.response_fn = echo
 
-        results = complete_batch(
+        batch = complete_batch(
             model="fake:model",
             prompt_list=["first", "second", "third"],
         )
 
-        assert len(results) == 3
-        assert results[0].content == "first"
-        assert results[1].content == "second"
-        assert results[2].content == "third"
+        assert len(batch) == 3
+        assert batch[0].content == "first"
+        assert batch[1].content == "second"
+        assert batch[2].content == "third"
+        assert len(batch.errors) == 0
 
     def test_captures_per_item_exceptions(self, patch_load_provider):
         def fail_on_second(request, api_key):
@@ -177,11 +178,13 @@ class TestCompleteBatch:
 
         patch_load_provider.response_fn = fail_on_second
 
-        results = complete_batch(
+        batch = complete_batch(
             model="fake:model",
             prompt_list=["good", "fail", "good"],
         )
 
-        assert isinstance(results[0], CompletionResponse)
-        assert isinstance(results[1], RuntimeError)
-        assert isinstance(results[2], CompletionResponse)
+        assert isinstance(batch[0], CompletionResponse)
+        assert isinstance(batch[1], RuntimeError)
+        assert isinstance(batch[2], CompletionResponse)
+        assert len(batch.responses) == 2
+        assert len(batch.errors) == 1

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -181,7 +181,7 @@ class TestOutputSingleResponse:
 class TestCompletionBatch:
     def test_aggregates_tokens(self):
         batch = CompletionBatch(
-            responses=[
+            results=[
                 _resp(input_tokens=10, output_tokens=5, latency=0.1),
                 _resp(input_tokens=20, output_tokens=15, latency=0.2),
             ]
@@ -191,14 +191,14 @@ class TestCompletionBatch:
 
     def test_latency_is_max(self):
         batch = CompletionBatch(
-            responses=[_resp(latency=0.1), _resp(latency=0.5), _resp(latency=0.3)]
+            results=[_resp(latency=0.1), _resp(latency=0.5), _resp(latency=0.3)]
         )
         assert batch.latency == 0.5
 
     def test_collects_parsed_objects(self):
         r1 = _resp(parsed=SingleField(summary="a"))
         r2 = _resp(parsed=SingleField(summary="b"))
-        batch = CompletionBatch(responses=[r1, r2])
+        batch = CompletionBatch(results=[r1, r2])
 
         assert len(batch.parsed) == 2
         assert batch.parsed[0].summary == "a"
@@ -207,20 +207,45 @@ class TestCompletionBatch:
     def test_skips_none_parsed(self):
         r1 = _resp(parsed=SingleField(summary="a"))
         r2 = _resp(parsed=None)
-        batch = CompletionBatch(responses=[r1, r2])
+        batch = CompletionBatch(results=[r1, r2])
         assert len(batch.parsed) == 1
 
     def test_empty_batch(self):
-        batch = CompletionBatch(responses=[])
+        batch = CompletionBatch(results=[])
         assert batch.input_tokens == 0
         assert batch.output_tokens == 0
         assert batch.latency == 0.0
         assert batch.parsed == []
 
     def test_frozen(self):
-        batch = CompletionBatch(responses=[])
+        batch = CompletionBatch(results=[])
         with pytest.raises(FrozenInstanceError):
-            batch.responses = [_resp()]
+            batch.results = [_resp()]
+
+    def test_exceptions_are_separated_from_responses(self):
+        r1 = _resp(input_tokens=5, output_tokens=3, latency=0.1)
+        err = RuntimeError("boom")
+        r2 = _resp(input_tokens=7, output_tokens=4, latency=0.2)
+        batch = CompletionBatch(results=[r1, err, r2])
+
+        # responses / errors split correctly, preserving order
+        assert batch.responses == [r1, r2]
+        assert batch.errors == [err]
+
+        # aggregates ignore the exception
+        assert batch.input_tokens == 12
+        assert batch.output_tokens == 7
+        assert batch.latency == 0.2
+
+    def test_iterable_and_indexable(self):
+        r1 = _resp()
+        err = RuntimeError("boom")
+        batch = CompletionBatch(results=[r1, err])
+
+        assert len(batch) == 2
+        assert batch[0] is r1
+        assert batch[1] is err
+        assert list(batch) == [r1, err]
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +256,7 @@ class TestCompletionBatch:
 class TestCompletionBatchOutput:
     def test_single_field_models_unwrap(self):
         batch = CompletionBatch(
-            responses=[
+            results=[
                 _resp(parsed=SingleField(summary="a")),
                 _resp(parsed=SingleField(summary="b")),
             ]
@@ -241,12 +266,12 @@ class TestCompletionBatchOutput:
     def test_multi_field_models_stay_as_models(self):
         m1 = MultiField(title="A", score=0.9)
         m2 = MultiField(title="B", score=0.8)
-        batch = CompletionBatch(responses=[_resp(parsed=m1), _resp(parsed=m2)])
+        batch = CompletionBatch(results=[_resp(parsed=m1), _resp(parsed=m2)])
         assert batch.output == [m1, m2]
 
     def test_list_fields_flatten(self):
         batch = CompletionBatch(
-            responses=[
+            results=[
                 _resp(parsed=ListField(items=["a", "b"])),
                 _resp(parsed=ListField(items=["c"])),
             ]
@@ -254,7 +279,7 @@ class TestCompletionBatchOutput:
         assert batch.output == ["a", "b", "c"]
 
     def test_empty_batch_returns_empty_list(self):
-        assert CompletionBatch(responses=[]).output == []
+        assert CompletionBatch(results=[]).output == []
 
     def test_mixed_list_and_scalar_does_not_flatten(self):
         """When not all outputs are lists, no flattening occurs."""
@@ -263,7 +288,7 @@ class TestCompletionBatchOutput:
             value: str
 
         batch = CompletionBatch(
-            responses=[
+            results=[
                 _resp(parsed=ListField(items=["a", "b"])),
                 _resp(parsed=MixedField(value="c")),
             ]

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -127,11 +127,11 @@ class TestObserverWithBatch:
         test should be flipped to assert propagation.
         """
         with observe() as obs:
-            results = complete_batch(
+            batch = complete_batch(
                 model="fake:model",
                 prompt_list=["a", "b", "c"],
                 max_workers=2,
             )
 
-        assert len(results) == 3
+        assert len(batch) == 3
         assert obs.records == []

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -120,11 +120,10 @@ class TestObserverScope:
 
 
 class TestObserverWithBatch:
-    def test_batch_calls_do_not_propagate_to_observer(self, patch_load_provider):
-        """Documented behavior: contextvars don't follow threads spawned by
-        ``complete_batch``, so calls inside the pool are not recorded.
-        If this ever changes (e.g. via ``contextvars.copy_context``), this
-        test should be flipped to assert propagation.
+    def test_batch_calls_propagate_to_observer(self, patch_load_provider):
+        """``parallelize_function`` snapshots the caller's context per task
+        (via :func:`contextvars.copy_context`), so completions made on the
+        thread pool inside ``complete_batch`` land on the active observer.
         """
         with observe() as obs:
             batch = complete_batch(
@@ -134,4 +133,25 @@ class TestObserverWithBatch:
             )
 
         assert len(batch) == 3
-        assert obs.records == []
+        assert len(obs.records) == 3
+        # Order of completion is non-deterministic across threads, but the
+        # set of recorded prompts must match the inputs exactly.
+        assert {r.request.prompt[0].content for r in obs.records} == {"a", "b", "c"}
+
+    def test_batch_observer_isolated_from_outer_scope(self, patch_load_provider):
+        """Each worker task runs inside its own context snapshot, so context
+        mutations performed by other tasks (or by sibling code) must not
+        leak between them. Here we verify that completions made *after* the
+        batch do not double-record on the inner observer.
+        """
+        with observe() as outer:
+            complete_batch(
+                model="fake:model",
+                prompt_list=["x", "y"],
+                max_workers=2,
+            )
+            complete(model="fake:model", prompt="z")
+
+        # 2 from the batch + 1 from the direct call.
+        assert len(outer.records) == 3
+        assert {r.request.prompt[0].content for r in outer.records} == {"x", "y", "z"}

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "lmdk"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "lmdk"
-version = "1.8.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
# Description
- Force `comple_batch` to return `BatchCompletion`
- Ensure that the threading parallelization carries the `context`, so that `observe` works on batch completion too

## Linked Issues
None

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
