### PR TITLE
feat(llamacpp): implement structured output

### DIFF
--- a/src/lmdk/providers/llamacpp.py
+++ b/src/lmdk/providers/llamacpp.py
@@ -42,15 +42,21 @@ class LlamacppProvider(Provider):
     @classmethod
     def _build_payload(cls, request: CompletionRequest, stream: bool = False) -> dict:
         """Build the full request payload for the llamacpp API."""
-        if request.output_schema:
-            raise NotImplementedError("Structured output is not implemented for LlamacppProvider.")
-
         payload: dict = {
             "model": request.model_id,
             "messages": cls._build_prompt_payload(request),
             "stream": stream,
             **(request.generation_kwargs or {}),
         }
+
+        if request.output_schema and not stream:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": request.output_schema.__name__,
+                    "schema": request.output_schema.model_json_schema(),
+                },
+            }
         return payload
 
     @classmethod

--- a/tests/test_llamacpp.py
+++ b/tests/test_llamacpp.py
@@ -3,7 +3,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
+from pydantic import BaseModel
 
 from lmdk.datatypes import CompletionRequest, UserMessage
 from lmdk.provider import RawResponse
@@ -51,6 +51,21 @@ def _mock_stream_response(tokens: list[str]):
     resp.status_code = 200
     resp.iter_lines.return_value = iter(lines)
     return resp
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+
+class Ingredient(BaseModel):
+    name: str
+    quantity: int
+    unit: str = ""
+
+
+class Recipe(BaseModel):
+    ingredients: list[Ingredient]
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +127,7 @@ class TestSendRequest:
         payload = call_kwargs.kwargs.get("json") or call_kwargs[1]["json"]
         assert payload["model"] == "any-model"
         assert payload["stream"] is False
+        assert "response_format" not in payload
 
     def test_generation_kwargs_forwarded(self):
         mock_resp = _mock_chat_response()
@@ -124,17 +140,45 @@ class TestSendRequest:
         assert payload["temperature"] == 0.9
         assert payload["max_tokens"] == 10
 
-    def test_structured_output_not_implemented(self):
-        """Verify that output_schema raises NotImplementedError."""
-        from pydantic import BaseModel
-
-        class Person(BaseModel):
-            name: str
-
+    def test_structured_output_payload(self):
+        """Verify that response_format is included for structured output."""
+        content = '{"name": "Alice", "age": 30}'
+        mock_resp = _mock_chat_response(content=content)
         request = _make_request(output_schema=Person)
         credentials = {"LLAMACPP_URL": "localhost", "LLAMACPP_PORT": "8080"}
-        with pytest.raises(NotImplementedError, match="Structured output is not implemented"):
-            LlamacppProvider._send_request(request, credentials=credentials)
+        with patch("lmdk.provider.requests.post", return_value=mock_resp) as mock_post:
+            result = LlamacppProvider._send_request(request, credentials=credentials)
+
+        assert result.content == content
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        rf = payload["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "Person"
+        assert "schema" in rf["json_schema"]
+
+    def test_structured_output_nested_payload(self):
+        """Verify that nested schemas produce the correct response_format."""
+        content = json.dumps(
+            {
+                "ingredients": [
+                    {"name": "tomato", "quantity": 5, "unit": "pieces"},
+                    {"name": "salt", "quantity": 1, "unit": "tsp"},
+                ]
+            }
+        )
+        mock_resp = _mock_chat_response(content=content)
+        request = _make_request(output_schema=Recipe)
+        credentials = {"LLAMACPP_URL": "localhost", "LLAMACPP_PORT": "8080"}
+        with patch("lmdk.provider.requests.post", return_value=mock_resp) as mock_post:
+            result = LlamacppProvider._send_request(request, credentials=credentials)
+
+        assert result.content == content
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        rf = payload["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "Recipe"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "lmdk"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
# Description
Allowed the structured output that llamacpp server already allows in the OpenAI compatible endpoint.

## Linked Issues
Closes #14 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
