### PR TITLE
ci: pass staged file paths from pre-commit hooks to just recipes

### DIFF
--- a/example.py
+++ b/example.py
@@ -15,6 +15,7 @@ section never blocks the rest. Look for [OK] and [FAILED] in the output.
 """
 
 import argparse
+from collections.abc import Callable
 
 from pydantic import BaseModel
 
@@ -45,6 +46,15 @@ def section(number: int, title: str) -> None:
     print(SEPARATOR)
 
 
+def run_section(number: int, title: str, action: Callable[[], None]) -> None:
+    """Run one example section, printing failures without stopping the script."""
+    section(number, title)
+    try:
+        action()
+    except Exception as e:
+        print(f"[FAILED] {title} -> {type(e).__name__}: {e}")
+
+
 # ── Pydantic schemas (defined at module level for reuse) ──────────────────
 
 
@@ -73,197 +83,144 @@ class City(BaseModel):
     population_million: float
 
 
+# ── Section runners ───────────────────────────────────────────────────────
+
+
+def _basic_text_completion(model: str) -> None:
+    response = complete(model=model, prompt="Say hello in one sentence.")
+    print_response("Basic text completion", response)
+
+
+def _multi_turn_conversation(model: str) -> None:
+    prompt = [
+        UserMessage("My name is Alice."),
+        AssistantMessage("Nice to meet you, Alice!"),
+        UserMessage("What is my name?"),
+    ]
+    response = complete(model=model, prompt=prompt)
+    print_response("Multi-turn conversation", response)
+
+
+def _system_instruction(model: str) -> None:
+    response = complete(
+        model=model,
+        prompt="Hi!",
+        system_instruction="You are a pirate. Always answer in pirate speak.",
+    )
+    print_response("System instruction", response)
+
+
+def _generation_kwargs(model: str) -> None:
+    response = complete(
+        model=model,
+        prompt="Write a poem.",
+        generation_kwargs={"temperature": 0.9, "max_tokens": 10},
+    )
+    print_response("Generation kwargs", response)
+
+
+def _streaming(model: str) -> None:
+    token_iter = complete(model=model, prompt="Count from 1 to 5.", stream=True)
+    print("[OK] Streaming")
+    print("  tokens: ", end="")
+    for token in token_iter:
+        print(token, end="", flush=True)
+    print()
+
+
+def _model_fallback(model: str) -> None:
+    provider = model.split(":")[0]
+    response = complete(
+        model=[f"{provider}:nonexistent-model-12345", model],
+        prompt="Say 'fallback worked' and nothing else.",
+    )
+    print_response("Model fallback", response)
+
+
+def _structured_output_simple(model: str) -> None:
+    response = complete(
+        model=model,
+        prompt="My coworker Jesus is 33 years old.",
+        output_schema=Person,
+    )
+    print_response("Structured output (simple)", response)
+    print(f"  type(.parsed) = {type(response.parsed).__name__}")
+    print(f"  type(.output) = {type(response.output).__name__}")
+
+
+def _structured_output_compound(model: str) -> None:
+    response = complete(
+        model=model,
+        prompt="How do I make gazpacho?",
+        output_schema=Recipe,
+    )
+    print_response("Structured output (compound)", response)
+
+
+def _single_field_unwrapping(model: str) -> None:
+    response = complete(
+        model=model,
+        prompt="Summarize the theory of relativity in one sentence.",
+        output_schema=Summary,
+    )
+    print_response("Single-field unwrapping", response)
+    print(f"  type(.parsed) = {type(response.parsed).__name__}  (full BaseModel)")
+    print(f"  type(.output) = {type(response.output).__name__}  (unwrapped field)")
+
+
+def _batch_responses(model: str) -> None:
+    batch = complete_batch(
+        model=model,
+        prompt_list=["Say 'hello' and nothing else.", "Say 'hola' and nothing else."],
+    )
+    for i, result in enumerate(batch):
+        if isinstance(result, Exception):
+            print(f"  [{i}] [FAILED] {type(result).__name__}: {result}")
+        else:
+            print(
+                f"  [{i}] [OK] content={result.content!r}  "
+                f"tokens={result.input_tokens}+{result.output_tokens}  "
+                f"latency={result.latency:.3f}s"
+            )
+    print(
+        f"  batch totals: input={batch.input_tokens}  output={batch.output_tokens}  "
+        f"latency={batch.latency:.3f}s  errors={len(batch.errors)}"
+    )
+
+
+def _batch_with_structured_output(model: str) -> None:
+    batch = complete_batch(
+        model=model,
+        prompt_list=[
+            "Tell me about Tokyo.",
+            "Tell me about Paris.",
+        ],
+        output_schema=City,
+    )
+    for i, result in enumerate(batch):
+        if isinstance(result, Exception):
+            print(f"  [{i}] [FAILED] {type(result).__name__}: {result}")
+        else:
+            print(f"  [{i}] [OK] parsed={result.parsed!r}  output={result.output!r}")
+
+
 # ── Main ──────────────────────────────────────────────────────────────────
 
 
 def main(model: str) -> None:
     """Run all example sections against the given model."""
+    run_section(1, "Basic text completion", lambda: _basic_text_completion(model))
+    run_section(2, "Multi-turn conversation", lambda: _multi_turn_conversation(model))
+    run_section(3, "System instruction", lambda: _system_instruction(model))
+    run_section(4, "Generation kwargs", lambda: _generation_kwargs(model))
+    run_section(5, "Streaming", lambda: _streaming(model))
+    run_section(6, "Model fallback", lambda: _model_fallback(model))
+    run_section(7, "Structured output (simple)", lambda: _structured_output_simple(model))
+    run_section(8, "Structured output (compound)", lambda: _structured_output_compound(model))
+    run_section(9, "Single-field unwrapping", lambda: _single_field_unwrapping(model))
+    run_section(10, "Batch responses", lambda: _batch_responses(model))
+    run_section(11, "Batch with structured output", lambda: _batch_with_structured_output(model))
 
-    # ── Section 1: Basic text completion ──────────────────────────────────
-    # The simplest possible call: a model string and a plain text prompt.
-    # The string is automatically wrapped into a UserMessage.
-    section(1, "Basic text completion")
-    try:
-        response = complete(model=model, prompt="Say hello in one sentence.")
-        print_response("Basic text completion", response)
-    except Exception as e:
-        print(f"[FAILED] Basic text completion -> {type(e).__name__}: {e}")
-
-    # ── Section 2: Multi-turn conversation ────────────────────────────────
-    # Instead of a plain string, pass a list of Message objects to simulate
-    # a conversation with history.  UserMessage and AssistantMessage set the
-    # role automatically.
-    section(2, "Multi-turn conversation")
-    try:
-        prompt = [
-            UserMessage("My name is Alice."),
-            AssistantMessage("Nice to meet you, Alice!"),
-            UserMessage("What is my name?"),
-        ]
-        response = complete(model=model, prompt=prompt)
-        print_response("Multi-turn conversation", response)
-    except Exception as e:
-        print(f"[FAILED] Multi-turn conversation -> {type(e).__name__}: {e}")
-
-    # ── Section 3: System instruction ─────────────────────────────────────
-    # A system instruction is prepended to the conversation. Useful for setting
-    # the tone, persona, or constraints of the model.
-    section(3, "System instruction")
-    try:
-        response = complete(
-            model=model,
-            prompt="Hi!",
-            system_instruction="You are a pirate. Always answer in pirate speak.",
-        )
-        print_response("System instruction", response)
-    except Exception as e:
-        print(f"[FAILED] System instruction -> {type(e).__name__}: {e}")
-
-    # ── Section 4: Generation kwargs ──────────────────────────────────────
-    # Pass provider-specific generation parameters like temperature and
-    # max_tokens.  Default is {"temperature": 0} when not specified.
-    section(4, "Generation kwargs")
-    try:
-        response = complete(
-            model=model,
-            prompt="Write a poem.",
-            generation_kwargs={"temperature": 0.9, "max_tokens": 10},
-        )
-        print_response("Generation kwargs", response)
-    except Exception as e:
-        print(f"[FAILED] Generation kwargs -> {type(e).__name__}: {e}")
-
-    # ── Section 5: Streaming ─────────────────────────────────────────────
-    # stream=True returns an iterator of string tokens instead of a
-    # CompletionResponse.  Note: streaming and output_schema are mutually
-    # exclusive.
-    section(5, "Streaming")
-    try:
-        token_iter = complete(model=model, prompt="Count from 1 to 5.", stream=True)
-        print("[OK] Streaming")
-        print("  tokens: ", end="")
-        for token in token_iter:
-            print(token, end="", flush=True)
-        print()  # newline after stream
-    except Exception as e:
-        print(f"[FAILED] Streaming -> {type(e).__name__}: {e}")
-
-    # ── Section 6: Model fallback ────────────────────────────────────────
-    # Pass a list of models. lmdk tries each in order, falling back to the
-    # next on failure.  Here the first model uses a non-existent model ID
-    # (same provider), so the API call should fail and the second should
-    # succeed.
-    section(6, "Model fallback")
-    provider = model.split(":")[0]
-    try:
-        response = complete(
-            model=[f"{provider}:nonexistent-model-12345", model],
-            prompt="Say 'fallback worked' and nothing else.",
-        )
-        print_response("Model fallback", response)
-    except Exception as e:
-        print(f"[FAILED] Model fallback -> {type(e).__name__}: {e}")
-
-    # ── Section 7: Structured output (simple) ────────────────────────────
-    # Pass a Pydantic BaseModel as output_schema.  The provider must return
-    # JSON that validates against this schema.  The parsed object is available
-    # in response.parsed, and response.output applies unwrapping logic.
-    section(7, "Structured output (simple)")
-    try:
-        response = complete(
-            model=model,
-            prompt="My coworker Jesus is 33 years old.",
-            output_schema=Person,
-        )
-        print_response("Structured output (simple)", response)
-        print(f"  type(.parsed) = {type(response.parsed).__name__}")
-        print(f"  type(.output) = {type(response.output).__name__}")
-    except Exception as e:
-        print(f"[FAILED] Structured output (simple) -> {type(e).__name__}: {e}")
-
-    # ── Section 8: Structured output (compound / nested) ─────────────────
-    # Nested Pydantic models work too.  This tests that the provider can
-    # handle more complex JSON schemas.
-    section(8, "Structured output (compound)")
-    try:
-        response = complete(
-            model=model,
-            prompt="How do I make gazpacho?",
-            output_schema=Recipe,
-        )
-        print_response("Structured output (compound)", response)
-    except Exception as e:
-        print(f"[FAILED] Structured output (compound) -> {type(e).__name__}: {e}")
-
-    # ── Section 9: Single-field unwrapping ────────────────────────────────
-    # When the output_schema has exactly ONE field, response.output returns
-    # just that field's value (not the whole BaseModel).  This is a convenience
-    # for common patterns like wrapping a single list or string in a schema.
-    #
-    # Compare .parsed (the full BaseModel) vs .output (the unwrapped value):
-    #   .parsed  -> Summary(text="...")
-    #   .output  -> "..."
-    section(9, "Single-field unwrapping")
-    try:
-        response = complete(
-            model=model,
-            prompt="Summarize the theory of relativity in one sentence.",
-            output_schema=Summary,
-        )
-        print_response("Single-field unwrapping", response)
-        print(f"  type(.parsed) = {type(response.parsed).__name__}  (full BaseModel)")
-        print(f"  type(.output) = {type(response.output).__name__}  (unwrapped field)")
-    except Exception as e:
-        print(f"[FAILED] Single-field unwrapping -> {type(e).__name__}: {e}")
-
-    # ── Section 10: Batch responses ───────────────────────────────────────
-    # complete_batch sends multiple prompts in parallel using a thread
-    # pool and returns a CompletionBatch. Iterating yields each outcome,
-    # which is either a CompletionResponse or an Exception.
-    section(10, "Batch responses")
-    try:
-        batch = complete_batch(
-            model=model,
-            prompt_list=["Say 'hello' and nothing else.", "Say 'hola' and nothing else."],
-        )
-        for i, result in enumerate(batch):
-            if isinstance(result, Exception):
-                print(f"  [{i}] [FAILED] {type(result).__name__}: {result}")
-            else:
-                print(
-                    f"  [{i}] [OK] content={result.content!r}  "
-                    f"tokens={result.input_tokens}+{result.output_tokens}  "
-                    f"latency={result.latency:.3f}s"
-                )
-        print(
-            f"  batch totals: input={batch.input_tokens}  output={batch.output_tokens}  "
-            f"latency={batch.latency:.3f}s  errors={len(batch.errors)}"
-        )
-    except Exception as e:
-        print(f"[FAILED] Batch responses -> {type(e).__name__}: {e}")
-
-    # ── Section 11: Batch with structured output ──────────────────────────
-    # Batch mode also supports output_schema.  Each response in the list
-    # will have .parsed and .output populated.
-    section(11, "Batch with structured output")
-    try:
-        batch = complete_batch(
-            model=model,
-            prompt_list=[
-                "Tell me about Tokyo.",
-                "Tell me about Paris.",
-            ],
-            output_schema=City,
-        )
-        for i, result in enumerate(batch):
-            if isinstance(result, Exception):
-                print(f"  [{i}] [FAILED] {type(result).__name__}: {result}")
-            else:
-                print(f"  [{i}] [OK] parsed={result.parsed!r}  output={result.output!r}")
-    except Exception as e:
-        print(f"[FAILED] Batch with structured output -> {type(e).__name__}: {e}")
-
-    # ── Done ──────────────────────────────────────────────────────────────
     print(f"\n{SEPARATOR}")
     print("  All sections executed. Check [OK] / [FAILED] above.")
     print(SEPARATOR)

--- a/justfile
+++ b/justfile
@@ -27,15 +27,15 @@ run-hooks:
     prek run --show-diff-on-failure --color=always -a
 
 # Code quality ----------------------------------------------------------------
-format:
-    uv run ruff check --fix .
-    uv run ruff format .
+format *paths=".":
+    uv run ruff check --fix {{ paths }}
+    uv run ruff format {{ paths }}
 
-check-types:
-    uv run ty check src
+check-types *paths=".":
+    uv run ty check {{ paths }}
 
-check-complexity:
-    uv run complexipy src
+check-complexity *paths=".":
+    uv run complexipy {{ paths }}
 
 # Test and run ----------------------------------------------------------------
 test target="":

--- a/prek.toml
+++ b/prek.toml
@@ -48,7 +48,6 @@ name = "ruff-format"
 entry = "just format"
 language = "system"
 types = ["python"]
-pass_filenames = false
 
 # Static type checking via ty
 [[repos.hooks]]
@@ -57,7 +56,6 @@ name = "check-types"
 entry = "just check-types"
 language = "system"
 types = ["python"]
-pass_filenames = false
 
 # Cyclomatic complexity via complexipy
 [[repos.hooks]]
@@ -66,4 +64,3 @@ name = "check-complexity"
 entry = "just check-complexity"
 language = "system"
 types = ["python"]
-pass_filenames = false

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -165,9 +165,9 @@ class TestCompleteBatch:
         )
 
         assert len(batch) == 3
-        assert batch[0].content == "first"
-        assert batch[1].content == "second"
-        assert batch[2].content == "third"
+        assert batch.responses[0].content == "first"
+        assert batch.responses[1].content == "second"
+        assert batch.responses[2].content == "third"
         assert len(batch.errors) == 0
 
     def test_captures_per_item_exceptions(self, patch_load_provider):

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -89,7 +89,7 @@ class TestCompletionRequest:
             generation_kwargs={},
         )
         with pytest.raises(FrozenInstanceError):
-            req.model_id = "other"
+            req.model_id = "other"  # ty: ignore[invalid-assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -123,7 +123,9 @@ class TestCompletionResponse:
             content="happy", input_tokens=1, output_tokens=1, latency=0.0, parsed=mood
         )
         assert resp.parsed == mood
-        assert resp.parsed.label == "happy"
+        parsed = resp.parsed
+        assert parsed is not None
+        assert parsed.label == "happy"
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +203,9 @@ class TestCompletionBatch:
         batch = CompletionBatch(results=[r1, r2])
 
         assert len(batch.parsed) == 2
+        assert isinstance(batch.parsed[0], SingleField)
         assert batch.parsed[0].summary == "a"
+        assert isinstance(batch.parsed[1], SingleField)
         assert batch.parsed[1].summary == "b"
 
     def test_skips_none_parsed(self):
@@ -220,7 +224,7 @@ class TestCompletionBatch:
     def test_frozen(self):
         batch = CompletionBatch(results=[])
         with pytest.raises(FrozenInstanceError):
-            batch.results = [_resp()]
+            batch.results = [_resp()]  # ty: ignore[invalid-assignment]
 
     def test_exceptions_are_separated_from_responses(self):
         r1 = _resp(input_tokens=5, output_tokens=3, latency=0.1)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -63,7 +63,7 @@ class TestProviderError:
 
 class TestAllModelsFailedError:
     def test_summary_message(self):
-        errors = {
+        errors: dict[str, Exception] = {
             "provider_a:model1": ValueError("timeout"),
             "provider_b:model2": RuntimeError("crash"),
         }
@@ -73,7 +73,7 @@ class TestAllModelsFailedError:
         assert err.errors is errors
 
     def test_single_error(self):
-        errors = {"p:m": ValueError("fail")}
+        errors: dict[str, Exception] = {"p:m": ValueError("fail")}
         err = AllModelsFailedError(errors)
         assert "p:m" in str(err)
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -66,6 +66,7 @@ class TestProviderComplete:
 
         monkeypatch.setenv("SINGLE_KEY", "secret-value")
         result = StrProvider.complete(request=_make_request(), stream=False)
+        assert isinstance(result, CompletionResponse)
         assert result.content == "secret-value"
 
     def test_resolves_credentials_with_tuple(self, monkeypatch):
@@ -90,6 +91,7 @@ class TestProviderComplete:
         monkeypatch.setenv("KEY1", "val1")
         monkeypatch.setenv("KEY2", "val2")
         result = TupleProvider.complete(request=_make_request(), stream=False)
+        assert isinstance(result, CompletionResponse)
         assert result.content == "val1-val2"
 
     def test_delegates_to_complete(self, fake_provider):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -77,7 +77,7 @@ def test_telemetry_off_does_not_import_opentelemetry(monkeypatch):
     monkeypatch.setattr(importlib, "import_module", fail_on_import)
 
     with traced_completion("fake", "model", _request(), fallback_index=0) as telemetry:
-        telemetry.record_response(RawResponse(content="ok", input_tokens=1, output_tokens=2))
+        telemetry.record_response(CompletionResponse(content="ok", input_tokens=1, output_tokens=2))
 
     assert calls == []
 
@@ -92,7 +92,7 @@ def test_enabled_telemetry_gracefully_noops_when_opentelemetry_is_missing(monkey
     monkeypatch.setattr(importlib, "import_module", fail_for_otel)
 
     with traced_completion("fake", "model", _request(), fallback_index=0) as telemetry:
-        telemetry.record_response(RawResponse(content="ok", input_tokens=1, output_tokens=2))
+        telemetry.record_response(CompletionResponse(content="ok", input_tokens=1, output_tokens=2))
 
 
 def test_metadata_mode_records_span_attributes_and_metrics(
@@ -148,7 +148,7 @@ def test_content_mode_records_prompt_system_instruction_and_response(monkeypatch
     monkeypatch.setenv("LMDK_TELEMETRY", "content")
 
     with traced_completion("fake", "model", _request(), fallback_index=2) as telemetry:
-        telemetry.record_response(RawResponse(content="ok", input_tokens=1, output_tokens=2))
+        telemetry.record_response(CompletionResponse(content="ok", input_tokens=1, output_tokens=2))
 
     span = span_exporter.get_finished_spans()[0]
     assert json.loads(span.attributes["gen_ai.input.messages"]) == [

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "lmdk"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
# Description
Align pre-commit hook behavior with the copier template change from promptuna: local hooks now forward staged filenames to `just format`, `just check-types`, and `just check-complexity` instead of scanning fixed directories.

This makes hooks faster on commit and ensures tests and `example.py` are checked too. Follow-up fixes address type-checking issues in tests, reduce `example.py` complexity, and sync `uv.lock`.

## Linked Issues
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

## Test plan
- [x] `just run-hooks` passes on all files
- [x] `just check-types` passes
- [x] `just test` (existing suite unchanged functionally)