### PR TITLE
ci(just): pass --frozen to uv run commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -28,25 +28,25 @@ run-hooks:
 
 # Code quality ----------------------------------------------------------------
 format *paths=".":
-    uv run ruff check --fix {{ paths }}
-    uv run ruff format {{ paths }}
+    uv run --frozen ruff check --fix {{ paths }}
+    uv run --frozen ruff format {{ paths }}
 
 check-types *paths=".":
-    uv run ty check {{ paths }}
+    uv run --frozen ty check {{ paths }}
 
 check-complexity *paths=".":
-    uv run complexipy {{ paths }}
+    uv run --frozen complexipy {{ paths }}
 
 # Test and run ----------------------------------------------------------------
 test target="":
-    uv run pytest --cov --cov-fail-under=90 {{ target }}
+    uv run --frozen pytest --cov --cov-fail-under=90 {{ target }}
 
 run file:
-    uv run --env-file .env {{ file }}
+    uv run --frozen --env-file .env {{ file }}
 
 # Project specific commands ---------------------------------------------------
 ipython:
-    uv run ipython
+    uv run --frozen ipython
 
 validate model="":
-    uv run --env-file .env example.py {{ model }}
+    uv run --frozen --env-file .env example.py {{ model }}


### PR DESCRIPTION
# Description
Add `--frozen` to every `uv run` recipe in the justfile so local commands use the committed lockfile, consistent with `just install` and CI.

## Linked Issues
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Test plan
- [x] `just run-hooks` (unchanged behavior; hooks invoke the updated recipes)
- [x] `just test` uses `uv run --frozen`