### PR TITLE
fix(vertex): stringify enums so vertex does not crash when Literal is…

### DIFF
--- a/src/lmdk/providers/vertex.py
+++ b/src/lmdk/providers/vertex.py
@@ -1,5 +1,6 @@
 """Implements the provider to use models hosted in GCP Vertex API."""
 
+import json
 from collections.abc import Iterator
 
 from lmdk.datatypes import CompletionRequest
@@ -178,9 +179,20 @@ class VertexProvider(Provider):
         if "description" in node:
             result["description"] = node["description"]
 
-        # Enum values.
+        # Enum values. Vertex only accepts ``enum`` on STRING schemas, and only
+        # with string entries: ``{"type": "BOOLEAN", "enum": [false, true]}``
+        # (what ``Literal[False, True]`` compiles to) is rejected with HTTP 400.
+        # Stringifying the values would satisfy Vertex but break Pydantic
+        # ``Literal`` validation of the response, which does not coerce
+        # ``"true"`` to ``True``. So keep the real type and move the allowed
+        # values into the description, where the model still sees them.
         if "enum" in node:
-            result["enum"] = node["enum"]
+            if result.get("type") == "STRING":
+                result["enum"] = node["enum"]
+            else:
+                allowed = ", ".join(json.dumps(v) for v in node["enum"])
+                description = result.get("description", "")
+                result["description"] = f"{description} Allowed values: {allowed}.".strip()
 
         # Object properties.
         if "properties" in node:

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import Sequence
+from typing import Literal
 from unittest.mock import MagicMock, patch
 
 from conftest import make_completion_request
@@ -282,6 +283,27 @@ class TestPydanticSchemaToVertex:
         schema = Ingredient.model_json_schema()
         result = VertexProvider._pydantic_schema_to_vertex(schema)
         assert result["properties"]["unit"]["default"] == ""
+
+    def test_string_enum_kept(self):
+        class Choice(BaseModel):
+            pick: Literal["a", "b"]
+
+        result = VertexProvider._pydantic_schema_to_vertex(Choice.model_json_schema())
+        assert result["properties"]["pick"] == {"type": "STRING", "enum": ["a", "b"]}
+
+    def test_non_string_enum_moved_to_description(self):
+        """Vertex 400s on enum with a non-STRING type, so it must not be sent."""
+
+        class Verdict(BaseModel):
+            ok: Literal[False, True]
+            score: Literal[1, 2, 3]
+
+        result = VertexProvider._pydantic_schema_to_vertex(Verdict.model_json_schema())
+        ok, score = result["properties"]["ok"], result["properties"]["score"]
+        assert "enum" not in ok and "enum" not in score
+        assert ok["type"] == "BOOLEAN" and score["type"] == "INTEGER"
+        assert ok["description"] == "Allowed values: false, true."
+        assert score["description"] == "Allowed values: 1, 2, 3."
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description
Vertex only accepts enum on STRING schemas, with string entries. Mistral/OpenAI take standard JSON Schema, so
 they're fine. And just validate passes because example.py's schemas (Person, Recipe, City, Summary) contain only
 str/int/float — no Literal, so the broken path is never exercised. Any Ordinal metric on Vertex hits it; so does
 any Literal/Enum field in your own programs' output schemas.

## Linked Issues
None 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
