### PR TITLE
feat(bedrock): add AWS Bedrock provider for Anthropic models

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ from lmdk import complete
 
 model = "mistral:mistral-small-2603"
 # supports locations as in "vertex:gemini-2.5-flash@europe-west4"
+# or "bedrock:eu.anthropic.claude-opus-5@eu-central-1" (region inferred from the
+# geo prefix when omitted)
 ```
 
 <details>

--- a/src/lmdk/providers/bedrock.py
+++ b/src/lmdk/providers/bedrock.py
@@ -1,0 +1,167 @@
+"""Implements the provider to use Anthropic models hosted in AWS Bedrock.
+
+Bedrock exposes Claude through ``InvokeModel``, which is the Anthropic Messages
+API with a different envelope: bearer-token auth, the model in the URL instead
+of the body, an ``anthropic_version`` field, and a binary event stream instead
+of SSE. Everything else (payload shape, thinking, response blocks) is identical,
+so this provider subclasses :class:`AnthropicProvider` and only patches the
+differences.
+
+Two Bedrock-specific deviations:
+
+* Structured output is expressed as a forced tool call. Bedrock rejects
+  Anthropic's native ``output_config.format``.
+* Streaming responses use ``application/vnd.amazon.eventstream`` framing.
+"""
+
+import base64
+import json
+import struct
+from collections.abc import Iterator
+
+from lmdk.datatypes import CompletionRequest
+from lmdk.provider import RawResponse
+from lmdk.providers.anthropic import AnthropicProvider
+
+BEDROCK_ANTHROPIC_VERSION = "bedrock-2023-05-31"
+
+# Name of the synthetic tool used to emulate structured output.
+_SCHEMA_TOOL = "emit_structured_output"
+
+# Default region per geo prefix of the model ID (``eu.anthropic.claude-opus-5``).
+# A geo inference ID must be called from a region inside that geography.
+_GEO_REGIONS = {"eu": "eu-west-1", "us": "us-east-1", "au": "ap-southeast-2"}
+DEFAULT_REGION = "us-east-1"
+
+
+class BedrockProvider(AnthropicProvider):
+    """Provider for Anthropic models hosted on the AWS Bedrock runtime API."""
+
+    required_env = "AWS_BEARER_TOKEN_BEDROCK"
+
+    # ── Auth ──────────────────────────────────────────────────────────────
+
+    @classmethod
+    def _build_auth_headers(cls, credentials: dict[str, str]) -> dict:
+        """Return Bedrock API-key (bearer token) authentication headers."""
+        return {"Authorization": f"Bearer {credentials['AWS_BEARER_TOKEN_BEDROCK']}"}
+
+    # ── Model / region parsing ────────────────────────────────────────────
+
+    @classmethod
+    def _build_url(cls, model_id: str, *, stream: bool) -> str:
+        """Construct the ``invoke`` endpoint URL for *model_id*.
+
+        The model string may carry an ``@region`` suffix, e.g.
+        ``"eu.anthropic.claude-opus-5@eu-central-1"``. Without it the region is
+        inferred from the geo prefix of the model ID (``eu``/``us``/``au``).
+        """
+        if "@" in model_id:
+            model, region = model_id.rsplit("@", 1)
+        else:
+            model = model_id
+            region = _GEO_REGIONS.get(model.split(".", 1)[0], DEFAULT_REGION)
+        action = "invoke-with-response-stream" if stream else "invoke"
+        return f"https://bedrock-runtime.{region}.amazonaws.com/model/{model}/{action}"
+
+    # ── Request building ──────────────────────────────────────────────────
+
+    @classmethod
+    def _build_payload(cls, request: CompletionRequest, stream: bool = False) -> dict:
+        """Adapt the Anthropic payload to the Bedrock ``InvokeModel`` body.
+
+        The model and the stream flag move to the URL, ``anthropic_version`` is
+        required, and ``output_config.format`` is rewritten as a forced tool
+        call because Bedrock does not accept it.
+        """
+        payload = super()._build_payload(request, stream=stream)
+        payload.pop("model", None)
+        payload.pop("stream", None)
+        payload["anthropic_version"] = BEDROCK_ANTHROPIC_VERSION
+
+        output_config = payload.get("output_config", {})
+        schema_format = output_config.pop("format", None)
+        if schema_format:
+            payload["tools"] = [
+                {
+                    "name": _SCHEMA_TOOL,
+                    "description": "Return the answer as structured output.",
+                    "input_schema": schema_format["schema"],
+                }
+            ]
+            payload["tool_choice"] = {"type": "tool", "name": _SCHEMA_TOOL}
+        if not output_config:
+            payload.pop("output_config", None)
+
+        return payload
+
+    # ── Response extraction ───────────────────────────────────────────────
+
+    @classmethod
+    def _extract_text(cls, body: dict) -> str:
+        """Extract the answer, unwrapping the structured-output tool call."""
+        for block in body.get("content", []):
+            if block.get("type") == "tool_use" and block.get("name") == _SCHEMA_TOOL:
+                return json.dumps(block["input"])
+        return super()._extract_text(body)
+
+    # ── Provider interface implementation ─────────────────────────────────
+
+    @classmethod
+    def _send_request(cls, request: CompletionRequest, credentials: dict[str, str]) -> RawResponse:
+        response = cls._make_request(
+            cls._build_url(request.model_id, stream=False),
+            json=cls._build_payload(request, stream=False),
+            headers=cls._build_auth_headers(credentials),
+        )
+
+        body = response.json()
+        usage = body.get("usage", {})
+        return RawResponse(
+            content=cls._extract_text(body),
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            thinking=cls._extract_thinking(body),
+            thinking_tokens=usage.get("output_tokens_details", {}).get("thinking_tokens", 0),
+        )
+
+    @classmethod
+    def _stream_response(
+        cls, request: CompletionRequest, credentials: dict[str, str]
+    ) -> Iterator[str]:
+        response = cls._make_request(
+            cls._build_url(request.model_id, stream=True),
+            json=cls._build_payload(request, stream=True),
+            headers=cls._build_auth_headers(credentials),
+            stream=True,
+        )
+
+        for chunk in cls._iter_eventstream_chunks(response):
+            if chunk.get("type") == "content_block_delta":
+                delta = chunk.get("delta", {})
+                if delta.get("type") == "text_delta" and delta.get("text"):
+                    yield delta["text"]
+
+    @classmethod
+    def _iter_eventstream_chunks(cls, response) -> Iterator[dict]:
+        """Decode an ``application/vnd.amazon.eventstream`` body into JSON chunks.
+
+        Each message is framed as ``total_length | headers_length | prelude_crc
+        | headers | payload | message_crc`` (lengths are big-endian uint32).
+        The payload is ``{"bytes": <base64 Anthropic stream event>}``.
+        """
+        # ponytail: CRCs are not verified; requests already runs over TLS, and a
+        # corrupt frame surfaces as a JSON decode error. Add zlib.crc32 checks if
+        # silent truncation ever shows up.
+        buffer = b""
+        for data in response.iter_content(chunk_size=None):
+            buffer += data
+            while len(buffer) >= 12:
+                total_length, headers_length = struct.unpack(">II", buffer[:8])
+                if len(buffer) < total_length:
+                    break
+                payload = buffer[12 + headers_length : total_length - 4]
+                buffer = buffer[total_length:]
+                event = json.loads(payload)
+                if "bytes" in event:
+                    yield json.loads(base64.b64decode(event["bytes"]))

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -1,0 +1,151 @@
+"""Tests for lmdk.providers.bedrock — BedrockProvider."""
+
+import base64
+import json
+import struct
+from unittest.mock import MagicMock, patch
+
+from conftest import make_completion_request
+from pydantic import BaseModel
+
+from lmdk.providers.bedrock import (
+    _SCHEMA_TOOL,
+    BEDROCK_ANTHROPIC_VERSION,
+    DEFAULT_REGION,
+    BedrockProvider,
+)
+
+MODEL = "eu.anthropic.claude-opus-5"
+CREDENTIALS = {"AWS_BEARER_TOKEN_BEDROCK": "token-123"}
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+
+def _eventstream(chunks: list[dict]) -> bytes:
+    """Frame Anthropic stream events as an AWS ``vnd.amazon.eventstream`` body."""
+    body = b""
+    for chunk in chunks:
+        payload = json.dumps(
+            {"bytes": base64.b64encode(json.dumps(chunk).encode()).decode()}
+        ).encode()
+        headers = b":x"  # arbitrary header bytes; the decoder only skips them
+        total = 12 + len(headers) + len(payload) + 4
+        body += struct.pack(">III", total, len(headers), 0) + headers + payload + b"\0\0\0\0"
+    return body
+
+
+class TestBuildAuthHeaders:
+    def test_uses_bearer_token(self):
+        assert BedrockProvider._build_auth_headers(CREDENTIALS) == {
+            "Authorization": "Bearer token-123"
+        }
+
+
+class TestBuildUrl:
+    def test_region_inferred_from_geo_prefix(self):
+        url = BedrockProvider._build_url(MODEL, stream=False)
+        assert url == f"https://bedrock-runtime.eu-west-1.amazonaws.com/model/{MODEL}/invoke"
+
+    def test_explicit_region_suffix_wins(self):
+        url = BedrockProvider._build_url(f"{MODEL}@eu-central-1", stream=False)
+        assert url.startswith("https://bedrock-runtime.eu-central-1.amazonaws.com/")
+        assert url.endswith(f"/model/{MODEL}/invoke")
+
+    def test_unknown_prefix_falls_back_to_default_region(self):
+        url = BedrockProvider._build_url("anthropic.claude-opus-5", stream=False)
+        assert f"bedrock-runtime.{DEFAULT_REGION}." in url
+
+    def test_stream_action(self):
+        url = BedrockProvider._build_url(MODEL, stream=True)
+        assert url.endswith("/invoke-with-response-stream")
+
+
+class TestBuildPayload:
+    def test_model_and_stream_move_out_of_body(self):
+        payload = BedrockProvider._build_payload(make_completion_request(model_id=MODEL))
+        assert "model" not in payload
+        assert "stream" not in payload
+        assert payload["anthropic_version"] == BEDROCK_ANTHROPIC_VERSION
+
+    def test_no_empty_output_config(self):
+        payload = BedrockProvider._build_payload(make_completion_request(model_id=MODEL))
+        assert "output_config" not in payload
+
+    def test_thinking_effort_kept_in_output_config(self):
+        payload = BedrockProvider._build_payload(
+            make_completion_request(model_id=MODEL, thinking_effort="medium")
+        )
+        assert payload["thinking"] == {"type": "adaptive"}
+        assert payload["output_config"] == {"effort": "medium"}
+
+    def test_output_schema_becomes_forced_tool_call(self):
+        payload = BedrockProvider._build_payload(
+            make_completion_request(model_id=MODEL, output_schema=Person)
+        )
+        assert "output_config" not in payload
+        assert payload["tool_choice"] == {"type": "tool", "name": _SCHEMA_TOOL}
+        assert payload["tools"][0]["input_schema"]["properties"].keys() == {"name", "age"}
+
+
+class TestSendRequest:
+    def _mock_response(self, content_blocks: list[dict]):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "content": content_blocks,
+            "usage": {
+                "input_tokens": 11,
+                "output_tokens": 7,
+                "output_tokens_details": {"thinking_tokens": 3},
+            },
+        }
+        return resp
+
+    def test_plain_text(self):
+        resp = self._mock_response(
+            [{"type": "thinking", "thinking": "hmm"}, {"type": "text", "text": "hi"}]
+        )
+        with patch("lmdk.provider.requests.post", return_value=resp):
+            raw = BedrockProvider._send_request(
+                make_completion_request(model_id=MODEL), CREDENTIALS
+            )
+        assert (raw.content, raw.thinking) == ("hi", "hmm")
+        assert (raw.input_tokens, raw.output_tokens, raw.thinking_tokens) == (11, 7, 3)
+
+    def test_tool_use_is_serialized_as_json(self):
+        resp = self._mock_response(
+            [{"type": "tool_use", "name": _SCHEMA_TOOL, "input": {"name": "Ada", "age": 36}}]
+        )
+        with patch("lmdk.provider.requests.post", return_value=resp):
+            raw = BedrockProvider._send_request(
+                make_completion_request(model_id=MODEL, output_schema=Person), CREDENTIALS
+            )
+        assert Person.model_validate_json(raw.content) == Person(name="Ada", age=36)
+
+
+class TestStreamResponse:
+    def test_yields_only_text_deltas(self):
+        body = _eventstream(
+            [
+                {"type": "message_start"},
+                {"type": "content_block_delta", "delta": {"type": "thinking_delta", "text": "x"}},
+                {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "he"}},
+                {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "llo"}},
+                {"type": "message_stop"},
+            ]
+        )
+        resp = MagicMock()
+        resp.status_code = 200
+        # Split mid-frame to exercise the buffering path.
+        resp.iter_content.return_value = iter([body[:7], body[7:40], body[40:]])
+
+        with patch("lmdk.provider.requests.post", return_value=resp):
+            tokens = list(
+                BedrockProvider._stream_response(
+                    make_completion_request(model_id=MODEL), CREDENTIALS
+                )
+            )
+        assert "".join(tokens) == "hello"


### PR DESCRIPTION
# Description
Adds `BedrockProvider` so Anthropic models hosted on AWS Bedrock are reachable as `bedrock:<model-id>`, e.g. `bedrock:eu.anthropic.claude-opus-5`.

Bedrock's [`InvokeModel`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html) is the Anthropic Messages API with a different envelope, so `BedrockProvider` subclasses `AnthropicProvider` and patches only the four differences:

- **Auth**: `Authorization: Bearer $AWS_BEARER_TOKEN_BEDROCK`. No SigV4 signing, no `boto3`/`botocore` — zero new dependencies.
- **URL**: model ID and stream flag move out of the body, `anthropic_version` is required. Region comes from an `@region` suffix (same convention as `vertex`/`local`), or is inferred from the geo prefix (`eu.` → `eu-west-1`) so `bedrock:eu.anthropic.claude-opus-5` works with no extra config.
- **Structured output**: rewritten as a forced tool call. Bedrock rejects Anthropic's native `output_config.format` with `400 output_config.format: Extra inputs are not permitted`. Verified to work together with adaptive thinking.
- **Streaming**: `invoke-with-response-stream` returns `application/vnd.amazon.eventstream` rather than SSE, so ~12 lines decode the binary framing and hand the events to the inherited delta parsing.

Thinking (`thinking: {type: adaptive}` + `output_config.effort`) is inherited unchanged and works as-is on Bedrock.

Known simplification, marked with a `ponytail:` comment: event-stream frame CRCs are not verified (traffic is already over TLS, and a corrupt frame surfaces as a JSON decode error).

## Linked Issues
Closes #49

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

`just validate bedrock:eu.anthropic.claude-opus-5` → `[OK]` on all 12 sections.
`just test` → 328 passed, `providers/bedrock.py` at 100% coverage, total 97.9%.