### PR TITLE
fix(vertex): do not send thinkingLevel minimal to gemini-3.7-flash

### DIFF
--- a/src/lmdk/providers/vertex.py
+++ b/src/lmdk/providers/vertex.py
@@ -104,15 +104,18 @@ class VertexProvider(Provider):
 
         Gemini 3 cannot fully disable thinking. ``"none"`` maps to the practical
         minimum: ``"minimal"`` on Flash / Flash-Lite models, ``"low"`` on Pro
-        models (which reject ``"minimal"``). Returns ``None`` for non-Gemini-3
-        models so legacy ``thinkingBudget`` behaviour is unchanged.
+        models and on ``gemini-3.7-flash`` (both reject ``"minimal"`` with HTTP
+        400; Google lists minimal for 3.7 Flash as a fast follow). Returns
+        ``None`` for non-Gemini-3 models so legacy ``thinkingBudget`` behaviour
+        is unchanged.
         """
         model, _ = cls._parse_model_id(request.model_id)
         if not model.startswith("gemini-3"):
             return None
 
         if request.thinking_effort == "none":
-            return "low" if "pro" in model else "minimal"
+            no_minimal = "pro" in model or model.startswith("gemini-3.7-flash")
+            return "low" if no_minimal else "minimal"
         return request.thinking_effort
 
     @classmethod

--- a/tests/test_vertex.py
+++ b/tests/test_vertex.py
@@ -344,6 +344,11 @@ class TestBuildPayload:
         payload = VertexProvider._build_payload(request)
         assert payload["generationConfig"]["thinkingConfig"] == {"thinkingLevel": "low"}
 
+    def test_thinking_effort_none_maps_to_low_for_gemini_3_7_flash(self):
+        request = _make_request(model_id="gemini-3.7-flash")
+        payload = VertexProvider._build_payload(request)
+        assert payload["generationConfig"]["thinkingConfig"] == {"thinkingLevel": "low"}
+
     def test_thinking_config_can_be_set_via_generation_kwargs(self):
         request = _make_request(generation_kwargs={"thinkingConfig": {"thinkingLevel": "low"}})
         payload = VertexProvider._build_payload(request)


### PR DESCRIPTION
# Description
`gemini-3.7-flash` rejects `THINKING_LEVEL_MINIMAL` with `HTTP 400 - Thinking level is unsupported: THINKING_LEVEL_MINIMAL` ([documented on the model page](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-7-flash); Google lists minimal as a fast follow). Since `thinking_effort` defaults to `"none"`, which we mapped to `"minimal"` on Gemini 3 Flash models, *every* default request to `vertex:gemini-3.7-flash` failed while `low`/`medium`/`high` worked.

`"none"` now maps to `"low"` for `gemini-3.7-flash`, same as for Pro models. `gemini-3.6-flash` keeps `"minimal"` (0 thinking tokens). Side effect: `"none"` on 3.7 Flash spends ~150 thinking tokens instead of 0; revert the prefix check once Google ships minimal there.

`just validate vertex:gemini-3.7-flash@eu` now passes all sections.

## Linked Issues
<!-- Link to the issue(s) this PR fixes. Use "Fixes #123" or "Closes #123" -->

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.